### PR TITLE
Import antd modules from the es sub-directory, not from the lib

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,7 @@ module.exports = {
                     preventFullImport: true,
                 },
                 antd: {
-                    transform: 'antd/lib/${member}',
+                    transform: 'antd/es/${member}',
                     preventFullImport: true,
                 },
             },

--- a/src/HOC/wrapWithField.tsx
+++ b/src/HOC/wrapWithField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Field, BaseFieldProps } from 'redux-form';
 // import { Partial } from 'utility-types';
-import { FormItemProps } from 'antd/lib/form';
+import { FormItemProps } from 'antd/es/form';
 import { merge } from 'lodash';
 
 import { logger } from '../config';
@@ -47,7 +47,7 @@ function wrapWithField<ComponentProps, InjectedProps = {}>(
                  *
                  *    Type 'ComponentClass<ComponentProps, any>' is not assignable to type '"input"'
                  */
-                component={component as unknown as 'input'}
+                component={(component as unknown) as 'input'}
                 props={undefined}
                 {...mergedProps}
             />

--- a/src/components/Fields/CheckboxGroupField.ts
+++ b/src/components/Fields/CheckboxGroupField.ts
@@ -1,4 +1,4 @@
-import { CheckboxGroupProps } from 'antd/lib/checkbox';
+import { CheckboxGroupProps } from 'antd/es/checkbox';
 import CheckboxGroupInput from '../Inputs/CheckboxGroupInput';
 import wrapWithField from '../../HOC/wrapWithField';
 

--- a/src/components/Fields/NumberField.ts
+++ b/src/components/Fields/NumberField.ts
@@ -1,4 +1,4 @@
-import { InputNumberProps } from 'antd/lib/input-number';
+import { InputNumberProps } from 'antd/es/input-number';
 import NumberInput from '../Inputs/NumberInput';
 import wrapWithField from '../../HOC/wrapWithField';
 

--- a/src/components/Fields/RadioField.ts
+++ b/src/components/Fields/RadioField.ts
@@ -1,4 +1,4 @@
-import { RadioGroupProps } from 'antd/lib/radio';
+import { RadioGroupProps } from 'antd/es/radio';
 import RadioInput from '../Inputs/RadioInput';
 import wrapWithField from '../../HOC/wrapWithField';
 

--- a/src/components/Fields/SelectField.ts
+++ b/src/components/Fields/SelectField.ts
@@ -1,4 +1,4 @@
-import { SelectProps as AntdSelectProps  } from 'antd/lib/select';
+import { SelectProps as AntdSelectProps } from 'antd/es/select';
 import SelectInput, { SelectProps } from '../Inputs/SelectInput';
 import wrapWithField from '../../HOC/wrapWithField';
 

--- a/src/components/Fields/SliderField.ts
+++ b/src/components/Fields/SliderField.ts
@@ -1,4 +1,4 @@
-import { SliderProps } from 'antd/lib/slider';
+import { SliderProps } from 'antd/es/slider';
 import SliderInput from '../Inputs/SliderInput';
 import wrapWithField from '../../HOC/wrapWithField';
 

--- a/src/components/Fields/SwitchField.ts
+++ b/src/components/Fields/SwitchField.ts
@@ -1,4 +1,4 @@
-import { SwitchProps } from 'antd/lib/switch';
+import { SwitchProps } from 'antd/es/switch';
 import SwitchInput from '../Inputs/SwitchInput';
 import wrapWithField from '../../HOC/wrapWithField';
 

--- a/src/components/Fields/TextField.ts
+++ b/src/components/Fields/TextField.ts
@@ -1,4 +1,4 @@
-import { InputProps } from 'antd/lib/input';
+import { InputProps } from 'antd/es/input';
 import TextInput from '../Inputs/TextInput';
 import wrapWithField from '../../HOC/wrapWithField';
 

--- a/src/components/Fields/TextareaField.ts
+++ b/src/components/Fields/TextareaField.ts
@@ -1,4 +1,4 @@
-import { TextAreaProps } from 'antd/lib/input';
+import { TextAreaProps } from 'antd/es/input';
 import TextAreaInput from '../Inputs/TextareaInput';
 import wrapWithField from '../../HOC/wrapWithField';
 

--- a/src/components/Inputs/CheckboxGroupInput.ts
+++ b/src/components/Inputs/CheckboxGroupInput.ts
@@ -1,7 +1,7 @@
 import { FocusEvent } from 'react';
 import { customMap, createComponent } from 'redux-form-antd';
 import { WrappedFieldProps } from 'redux-form';
-import { default as Checkbox } from 'antd/lib/checkbox';
+import { default as Checkbox } from 'antd/es/checkbox';
 
 const CheckboxGroup = Checkbox.Group;
 
@@ -23,7 +23,7 @@ const checkboxGroupMap = customMap(
             onBlur(undefined);
         },
         value: !value ? defaultValue : value,
-    })
+    }),
 );
 
 export default createComponent(CheckboxGroup, checkboxGroupMap);

--- a/src/components/Inputs/PickerInput.ts
+++ b/src/components/Inputs/PickerInput.ts
@@ -2,10 +2,10 @@ import { FocusEvent } from 'react';
 import { Omit } from 'utility-types';
 import { customMap, createComponent } from 'redux-form-antd';
 import { WrappedFieldProps, BaseFieldProps, WrappedFieldInputProps } from 'redux-form';
-import TimePicker from 'antd/lib/time-picker';
-import DatePicker from 'antd/lib/date-picker';
-import { PickerProps as AntdPickerProps, SinglePickerProps } from 'antd/lib/date-picker/interface';
-import { FormItemProps } from 'antd/lib/form';
+import TimePicker from 'antd/es/time-picker';
+import DatePicker from 'antd/es/date-picker';
+import { PickerProps as AntdPickerProps, SinglePickerProps } from 'antd/es/date-picker/interface';
+import { FormItemProps } from 'antd/es/form';
 import moment from 'moment';
 
 import { logger } from '../../config';

--- a/src/components/Inputs/SelectInput.ts
+++ b/src/components/Inputs/SelectInput.ts
@@ -7,7 +7,7 @@ export interface OptionData {
     key: string | number;
 }
 
-// extra props that are not defined in SelectProps from antd/lib/select but rather added by redux-form-antd
+// extra props that are not defined in SelectProps from antd/es/select but rather added by redux-form-antd
 export interface SelectProps {
     multiple?: boolean;
     options: OptionData[];

--- a/src/components/Inputs/SwitchInput.ts
+++ b/src/components/Inputs/SwitchInput.ts
@@ -1,24 +1,19 @@
 import { FocusEvent } from 'react';
-import Switch from 'antd/lib/switch';
+import Switch from 'antd/es/switch';
 import { customMap, createComponent } from 'redux-form-antd';
 import { WrappedFieldProps } from 'redux-form';
 
-const switchMap = customMap(
-    (
-        mapProps,
-        { input: { onChange, onBlur, onFocus, value } }: WrappedFieldProps,
-    ) => ({
-        ...mapProps,
-        onChange,
-        onFocus: (e: FocusEvent) => {
-            onFocus(e);
-        },
-        onBlur: () => {
-            onBlur(undefined);
-        },
-        checked: Boolean(value),
-    })
-);
+const switchMap = customMap((mapProps, { input: { onChange, onBlur, onFocus, value } }: WrappedFieldProps) => ({
+    ...mapProps,
+    onChange,
+    onFocus: (e: FocusEvent) => {
+        onFocus(e);
+    },
+    onBlur: () => {
+        onBlur(undefined);
+    },
+    checked: Boolean(value),
+}));
 
 const SwitchField = createComponent(Switch, switchMap);
 


### PR DESCRIPTION
We have to decide which modules are we going to use, otherwise we will end up with including both antd/lib and antd/es directories in the final bundle.
I'd suggest using modules from the es directory that is much more tree-shaking friendly.