### PR TITLE
submitForm custom data parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ npm i -S @ackee/mateus
 
 ### <a name="action-creators"></a>Action creators
 
-#### <a name="submit-form-action-creator"></a>`submitForm(formId: string, submitActionCreator: () => object): function`
+#### <a name="submit-form-action-creator"></a>`submitForm(formId: string, submitActionCreator: () => object, customData?: object): function`
 
 - `formId` Form unique identificator
 - `submitActionCreator` Action creator for form specific submit action 
+- `customData` Object with custom data (e.g. URL parameter, redux dispatch function,..)
 - Returns Form submit handler that is used for `handleSubmit` prop of `redux-form` `Form`.
 
     Example - use `submitForm` in `react-redux` container
@@ -57,9 +58,9 @@ npm i -S @ackee/mateus
                 initialValues: {
                 },
             }),
-            dispatch => ({
+            (dispatch, ownProps) => ({
                 onSubmit: bindActionCreators(
-                    formActions.submitForm(formId, createUserAction),
+                    formActions.submitForm(formId, createUserAction, { someProp: ownProps.someProp }),
                     dispatch,
                 ),
             }),

--- a/src/services/actions.ts
+++ b/src/services/actions.ts
@@ -2,9 +2,10 @@ import { Action as ReduxAction } from 'redux';
 import { Action } from '../types';
 import actionTypes from './actionTypes';
 
-const submitForm = <FormValues = object>(form: string, submitActionCreator: ReduxAction) => {
+const submitForm = <FormValues = object>(form: string, submitActionCreator: ReduxAction, customData?: object) => {
     return (data: FormValues): Action => ({
         data,
+        customData,
         form,
         submitActionCreator,
         type: actionTypes.FORM_SUBMIT,


### PR DESCRIPTION
I've added an optional parameter `customData` to `submitForm` action creator. Reason for that is I need to pass `dispatch` function to Redux-Saga and I can't use `put` effect in my use case. I think it might be helpful to have this option in case any other data/parameters need to be passed through the action.